### PR TITLE
fix (Menu): remove checkbox overlay on Menu

### DIFF
--- a/components/header/Menu.tsx
+++ b/components/header/Menu.tsx
@@ -11,7 +11,7 @@ function MenuItem({ item }: { item: INavItem }) {
       <div class="collapse collapse-plus relative items-start">
         <input
           type="checkbox"
-          class="absolute left-0 w-full h-full top-0"
+          class="absolute left-0 w-full top-0"
         />
         <div class="collapse-title min-h-0 p-0 py-2.5 font-dm-sans font-normal text-sm px-0 flex items-center justify-between">
           {item.label}


### PR DESCRIPTION
# What is this contribution about?

This commit intends to remove an overlay bug that occurs in the Menu checkbox, which makes it impossible to access links in childrens.

## Extra info
https://github.com/yuriassuncx/FreeBarber/assets/104099580/95b28876-aa4f-410f-8b0b-76e99b5357b9

